### PR TITLE
fix: cffi issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.8-alpine
 
-RUN apk --update --no-cache add git bash
+RUN apk --update --no-cache add git bash libffi-dev build-base python3-dev
 RUN pip install PyGithub PyYAML
 
 COPY "emoji.py" "/emoji.py"


### PR DESCRIPTION
Missing gcc dependency to build cffi pip

This pull request is used to fix #

**If the issue for this pull request haven't existed yet, please create the issue first**
